### PR TITLE
Bugfix

### DIFF
--- a/scrubber/data/tautomers.txt
+++ b/scrubber/data/tautomers.txt
@@ -4,5 +4,5 @@
 [nX2,NX2,S,O,Se,Te,Cz0X3:1]:,=[c,C,NX2,nX2:6][C,c,NX2,nX2:5]:,=[C,c,NX2,nX2:2][C,c,NX2,nX2:7]:,=[C,c,NX2,nX2:8][Nh,nh,Sh,sh,Oh,oh,Seh,Teh,CX4z0h:3]>>[#1][N,n,S,O,Se,Te,Cz0X4:1][C,c,NX2,nX2:6]=[C,c:5][C,c,NX2,nX2:2]=[C,c,NX2,nX2:7][C,c,NX2,nX2:8]=[NX2,S,O,Se,Te,CX3z0:3] P-09
 KEEPMAX_SMARTS [a] aromatic
 KEEPMAX_SMARTS [OX1,SX1]=[CX3][NX3] amide
-KEEPMAX_SMARTS [CX4][CX3](=[OX1]) acetone
+KEEPMAX_SMARTS [CX4][CX3;PX4](=[OX1]) acetone 
 KEEPMIN_SMARTS [#6X3][NX4+1] anilinium


### PR DESCRIPTION
A bug was fixed that prevented users from embedding multiple conformers while also using the template matching option.
The logic for choosing a minimizer was simplified, making the code easier to read.
The default FF changed from UFF to MMFF94s, thanks @diogomart for the testing!!
The acetone tautomer was modified to include phosphorous. @diogomart I found this fix in my local repository, I think we did it together some time ago but it was never pushed.
