### PR TITLE
removed distutils dependency (deprecated)

### DIFF
--- a/scrubber/cli.py
+++ b/scrubber/cli.py
@@ -2,11 +2,24 @@ import multiprocessing
 import argparse
 
 # provide method to convert strings into boolean
-from distutils.util import strtobool
 from .transform.isomer import MoleculeIsomers
 from .storage import MoleculeProvider, MoleculeStorage, MoleculeIssueStorage
 from .geom.geometry import ParallelGeometryGenerator
 from .core import ScrubberCore
+
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
 
 
 # TODO source:


### PR DESCRIPTION
Removed `distutils` dependency which is not available on the newer versions of python. 