### PR TITLE
Flip amine substituents inside ring structure

### DIFF
--- a/scrubber/__init__.py
+++ b/scrubber/__init__.py
@@ -19,5 +19,6 @@ __all__ = [
     "Scrub",
     "gen3d",
     "SMIMolSupplierWrapper",
-    "utils"
+    "utils",
+    "amine_flip.py"
 ]

--- a/scrubber/amine_flip.py
+++ b/scrubber/amine_flip.py
@@ -9,14 +9,11 @@ def find_n_ring_substituents(mol):
     with two substituents (non-ring atoms).
     Return (n_idx, sub1_idx, sub2_idx) if found, else None.
     """
-    smarts = '[NRX4,NRX3]'
+    smarts = '[NRX4H1,NRX3]'
     patt = Chem.MolFromSmarts(smarts)
 
     matches = mol.GetSubstructMatches(patt)
 
-    if not matches:
-        return None
-    
     amines = []
 
     for match in matches:

--- a/scrubber/amine_flip.py
+++ b/scrubber/amine_flip.py
@@ -106,14 +106,6 @@ def swap_substituents(mol, coords, n_idx, sub1_idx, sub2_idx, ring_atom_indices)
 
     return coords_new
 
-def rotate_ring_atom(index, coords, rotaxis, angle, substituents):
-    affected = set([index])
-    # for _, info in substituents[index].items():
-    #     affected = affected.union(info["downstream_indices"])
-    new_coords = coords.copy()
-    for i in affected:
-        new_coords[i] = np.dot(rotation_matrix(rotaxis, angle), coords[i])
-    return coords
 
 def get_ring_atoms(mol, n_idx):
     """

--- a/scrubber/amine_flip.py
+++ b/scrubber/amine_flip.py
@@ -1,0 +1,162 @@
+from rdkit import Chem
+import numpy as np
+import math
+from .utils import rotation_matrix
+
+def find_n_ring_substituents(mol):
+    """
+    Find a positively charged N atom in a 5- or 6-membered ring
+    with two substituents (non-ring atoms).
+    Return (n_idx, sub1_idx, sub2_idx) if found, else None.
+    """
+    smarts = '[NRX4]'
+    patt = Chem.MolFromSmarts(smarts)
+
+    matches = mol.GetSubstructMatches(patt)
+    if not matches:
+        return None
+
+    for match in matches:
+        n_idx = match[0]
+        n_atom = mol.GetAtomWithIdx(n_idx)
+
+        neighbors = n_atom.GetNeighbors()
+        ring_neighbors = [a for a in neighbors if a.IsInRing()]
+        sub_neighbors = [a for a in neighbors if not a.IsInRing()]
+
+        if len(ring_neighbors) == 2 and len(sub_neighbors) == 2:
+            sub1_idx = sub_neighbors[0].GetIdx()
+            sub2_idx = sub_neighbors[1].GetIdx()
+            return (n_idx, sub1_idx, sub2_idx)
+
+    return None
+
+def get_substituent_tree(mol, root_idx, exclude_idx):
+    """
+    Return all atom indices in the substituent connected to root_idx,
+    excluding the path back to exclude_idx (typically the nitrogen).
+    """
+    visited = set()
+    stack = [root_idx]
+    substituent = []
+
+    while stack:
+        atom_idx = stack.pop()
+        if atom_idx in visited:
+            continue
+        visited.add(atom_idx)
+        substituent.append(atom_idx)
+        atom = mol.GetAtomWithIdx(atom_idx)
+        for neighbor in atom.GetNeighbors():
+            nbr_idx = neighbor.GetIdx()
+            if nbr_idx != exclude_idx and nbr_idx not in visited:
+                stack.append(nbr_idx)
+
+    return substituent
+
+def swap_substituents(mol, coords, n_idx, sub1_idx, sub2_idx, ring_atom_indices):
+
+    """
+    Rotate the two substituents around the axis bisecting the angle between the two ring atoms bonded to nitrogen.
+
+    coords: numpy array of shape (N_atoms, 3)
+    n_idx: index of nitrogen atom
+    sub1_idx: index of first substituent atom
+    sub2_idx: index of second substituent atom
+    ring_atom_indices: list of indices of atoms forming the ring
+
+    Returns a copy of the modified coords.
+    """
+    coords_new = coords.copy()
+
+    # Find the two ring atoms connected to nitrogen
+    ring_neighbors = []
+    nitrogen = mol.GetAtomWithIdx(n_idx)
+    neighbors = nitrogen.GetNeighbors()
+    for neighbor in neighbors:
+        idx = neighbor.GetIdx()
+        if idx not in [sub1_idx, sub2_idx]:
+            ring_neighbors.append(neighbor.GetIdx())
+
+    if len(ring_neighbors) != 2:
+        raise ValueError("Could not identify two ring atoms bonded to nitrogen")
+
+    r1 = coords[ring_neighbors[0]]
+    r2 = coords[ring_neighbors[1]]
+    n = coords[n_idx]
+
+    # Define vectors
+    v1 = r1 - n
+    v2 = r2 - n
+
+    # Axis is bisector of v1 and v2
+    bisector = v1 / np.linalg.norm(v1) + v2 / np.linalg.norm(v2)
+    bisector /= np.linalg.norm(bisector)
+
+    # Get full substituent trees
+    group1 = get_substituent_tree(mol, sub1_idx, n_idx)
+    group2 = get_substituent_tree(mol, sub2_idx, n_idx)
+
+
+    for sub_group in [group1, group2]:
+        for atom_idx in sub_group:
+            vec = coords[atom_idx] - n
+            rotated_vec = np.dot(rotation_matrix(bisector, math.pi), vec)
+            coords_new[atom_idx] = n + rotated_vec
+
+    return coords_new
+
+def rotate_ring_atom(index, coords, rotaxis, angle, substituents):
+    affected = set([index])
+    # for _, info in substituents[index].items():
+    #     affected = affected.union(info["downstream_indices"])
+    new_coords = coords.copy()
+    for i in affected:
+        new_coords[i] = np.dot(rotation_matrix(rotaxis, angle), coords[i])
+    return coords
+
+def get_ring_atoms(mol, n_idx):
+    """
+    Given the nitrogen index, find the ring it's part of and return the ring atom indices.
+    """
+    ring_info = mol.GetRingInfo()
+    for ring in ring_info.AtomRings():
+        if n_idx in ring and (len(ring) == 5 or len(ring) == 6):
+            return ring
+    return None
+
+# for debbuging .
+def molToXYZ(mol, coords):
+    """
+    Convert an RDKit mol and numpy array of coordinates to XYZ format string.
+    """
+    lines = [str(mol.GetNumAtoms()), "XYZ generated from RDKit"]
+    for atom, pos in zip(mol.GetAtoms(), coords):
+        sym = atom.GetSymbol()
+        x, y, z = pos
+        lines.append(f"{sym} {x:.6f} {y:.6f} {z:.6f}")
+    return "\n".join(lines)
+
+# testing
+# from rdkit.Chem import SDMolSupplier
+# sdf_path = "amine.sdf"  
+# suppl = SDMolSupplier(sdf_path, removeHs=False)
+
+# for mol in suppl:
+#     if mol is None:
+#         continue
+
+#     match = find_n_ring_substituents(mol)
+#     if match:
+#         n_idx, sub1_idx, sub2_idx = match
+#         ring_atoms = get_ring_atoms(mol, n_idx)
+#         conf = mol.GetConformer()
+#         coords = np.array([list(conf.GetAtomPosition(i)) for i in range(mol.GetNumAtoms())])
+
+#         new_coords = swap_substituents(coords, mol, n_idx, sub1_idx, sub2_idx, ring_atoms)
+
+#         print(f"Original coords for substituents: {coords[sub1_idx]}, {coords[sub2_idx]}")
+#         print(f"Swapped coords for substituents: {new_coords[sub1_idx]}, {new_coords[sub2_idx]}")
+#         break
+#     else:
+#         print("No matching nitrogen found.")

--- a/scrubber/amine_flip.py
+++ b/scrubber/amine_flip.py
@@ -9,10 +9,13 @@ def find_n_ring_substituents(mol):
     with two substituents (non-ring atoms).
     Return (n_idx, sub1_idx, sub2_idx) if found, else None.
     """
-    smarts = '[NRX4]'
+    smarts = '[NRX4,NRX3]'
     patt = Chem.MolFromSmarts(smarts)
 
     matches = mol.GetSubstructMatches(patt)
+    print("jani debug, matches")
+    print(matches)
+
     if not matches:
         return None
     
@@ -30,6 +33,9 @@ def find_n_ring_substituents(mol):
             sub1_idx = sub_neighbors[0].GetIdx()
             sub2_idx = sub_neighbors[1].GetIdx()
             amines.append((n_idx, sub1_idx, sub2_idx))
+        elif len(ring_neighbors) == 2 and len(sub_neighbors) == 1: # case with 1 substituent
+            sub1_idx = sub_neighbors[0].GetIdx()
+            amines.append((n_idx, sub1_idx))
 
     return amines
 
@@ -64,7 +70,7 @@ def swap_substituents(mol, coords, n_idx, sub1_idx, sub2_idx, ring_atom_indices)
     coords: numpy array of shape (N_atoms, 3)
     n_idx: index of nitrogen atom
     sub1_idx: index of first substituent atom
-    sub2_idx: index of second substituent atom
+    sub2_idx: index of second substituent atom; may be None
     ring_atom_indices: list of indices of atoms forming the ring
 
     Returns a copy of the modified coords.
@@ -97,8 +103,10 @@ def swap_substituents(mol, coords, n_idx, sub1_idx, sub2_idx, ring_atom_indices)
 
     # Get full substituent trees
     group1 = get_substituent_tree(mol, sub1_idx, n_idx)
-    group2 = get_substituent_tree(mol, sub2_idx, n_idx)
-
+    if sub2_idx is not None:
+        group2 = get_substituent_tree(mol, sub2_idx, n_idx)
+    else:
+        group2 = []
 
     for sub_group in [group1, group2]:
         for atom_idx in sub_group:

--- a/scrubber/amine_flip.py
+++ b/scrubber/amine_flip.py
@@ -5,7 +5,7 @@ from .utils import rotation_matrix
 
 def find_n_ring_substituents(mol):
     """
-    Find a positively charged N atom in a 5- or 6-membered ring
+    Find a positively charged N atom in a ring
     with two substituents (non-ring atoms).
     Return (n_idx, sub1_idx, sub2_idx) if found, else None.
     """

--- a/scrubber/amine_flip.py
+++ b/scrubber/amine_flip.py
@@ -15,6 +15,8 @@ def find_n_ring_substituents(mol):
     matches = mol.GetSubstructMatches(patt)
     if not matches:
         return None
+    
+    amines = []
 
     for match in matches:
         n_idx = match[0]
@@ -27,9 +29,9 @@ def find_n_ring_substituents(mol):
         if len(ring_neighbors) == 2 and len(sub_neighbors) == 2:
             sub1_idx = sub_neighbors[0].GetIdx()
             sub2_idx = sub_neighbors[1].GetIdx()
-            return (n_idx, sub1_idx, sub2_idx)
+            amines.append((n_idx, sub1_idx, sub2_idx))
 
-    return None
+    return amines
 
 def get_substituent_tree(mol, root_idx, exclude_idx):
     """

--- a/scrubber/amine_flip.py
+++ b/scrubber/amine_flip.py
@@ -13,8 +13,6 @@ def find_n_ring_substituents(mol):
     patt = Chem.MolFromSmarts(smarts)
 
     matches = mol.GetSubstructMatches(patt)
-    print("jani debug, matches")
-    print(matches)
 
     if not matches:
         return None

--- a/scrubber/ringfix.py
+++ b/scrubber/ringfix.py
@@ -260,6 +260,11 @@ def rotate_amine_substituents(mol: Mol,
                               energy_threshold: float, 
                               debug: bool):
     
+    """
+    Identify amine group in ring structure and swap equatorial and axial
+    substituents. Determine optimal structure with energy minimization. 
+    """
+    
     amine_match = am.find_n_ring_substituents(mol)
 
     if amine_match:
@@ -276,12 +281,14 @@ def rotate_amine_substituents(mol: Mol,
         
             old_energy = optimized_energies[0][1]
             new_energy = optimized_energies[1][1]
+
             if debug:
                 print(f"Initial energy: {old_energy}")
                 print(f"Initial coords:\n {am.molToXYZ(mol, coords)}")
                 print(f"Rotated energy: {new_energy}")
                 print(f"Rotated coords:\n {am.molToXYZ(mol, new_coords)}")
 
+            # determine optimal structure within energy threshold. 
             if new_energy - old_energy < -energy_threshold:
                 tmp.append(new_coords)
             elif new_energy - old_energy > energy_threshold:

--- a/scrubber/ringfix.py
+++ b/scrubber/ringfix.py
@@ -249,7 +249,7 @@ def fix_rings(mol: Mol, coords: list, use_energy: bool, energy_threshold: float,
         coords_list = tmp
     
     # check for rotatable ring amine group
-    coords_list = rotate_amine_substituents(mol, coords_list, max_ff_iter, energy_threshold)
+    coords_list = rotate_amine_substituents(mol, coords_list, max_ff_iter, energy_threshold, debug)
 
     return coords_list
 
@@ -257,10 +257,11 @@ def fix_rings(mol: Mol, coords: list, use_energy: bool, energy_threshold: float,
 def rotate_amine_substituents(mol: Mol, 
                               coords_list: List, 
                               max_ff_iter: int, 
-                              energy_threshold: float):
+                              energy_threshold: float, 
+                              debug: bool):
+    
     amine_match = am.find_n_ring_substituents(mol)
-    #jani debug
-    print("jani debug, amine_match: ", amine_match)
+
     if amine_match:
         n_idx, sub1_idx, sub2_idx = amine_match
         ring_atoms = am.get_ring_atoms(mol, n_idx)
@@ -275,10 +276,12 @@ def rotate_amine_substituents(mol: Mol,
         
             old_energy = optimized_energies[0][1]
             new_energy = optimized_energies[1][1]
-            print(f"jani debug, initial energy: {old_energy}")
-            print(f"jani debug, initial coords: {am.molToXYZ(mol, coords)}")
-            print(f"jani debug, rotate energy: {new_energy}")
-            print(f"jani debug, rotated coords: {am.molToXYZ(mol, new_coords)}")
+            if debug:
+                print(f"Initial energy: {old_energy}")
+                print(f"Initial coords:\n {am.molToXYZ(mol, coords)}")
+                print(f"Rotated energy: {new_energy}")
+                print(f"Rotated coords:\n {am.molToXYZ(mol, new_coords)}")
+
             if new_energy - old_energy < -energy_threshold:
                 tmp.append(new_coords)
             elif new_energy - old_energy > energy_threshold:
@@ -287,8 +290,6 @@ def rotate_amine_substituents(mol: Mol,
                 tmp.append(coords)
                 tmp.append(new_coords)
 
-        print("jani debug tmp")
-        print(tmp)
         return tmp
     else:
         return coords_list

--- a/scrubber/ringfix.py
+++ b/scrubber/ringfix.py
@@ -269,9 +269,16 @@ def rotate_amine_substituents(mol: Mol,
 
     if len(amine_match) == 0:
         return coords_list
+    
+    print("jani debug, amine_match")
+    print(amine_match)
 
     for match in amine_match:
-        n_idx, sub1_idx, sub2_idx = match
+        if len(match) == 3:
+            n_idx, sub1_idx, sub2_idx = match
+        elif len(match) == 2:
+            n_idx, sub1_idx = match
+            sub2_idx = None
         ring_atoms = am.get_ring_atoms(mol, n_idx)
         tmp = []
         for coords in coords_list:
@@ -423,6 +430,7 @@ def expand_reasonable_chairs(
     new_axial_likeliness += calc_anomeric_penalty(mol, substituents, newpos)
 
     # a little more debugging
+    debug=True
     if debug:
         print("Mol 1")
         print(am.molToXYZ(mol, coords))

--- a/scrubber/ringfix.py
+++ b/scrubber/ringfix.py
@@ -247,9 +247,6 @@ def fix_rings(mol: Mol, coords: list, use_energy: bool, energy_threshold: float,
             new_coords = expand_ring6_rot5(coords, idxs, substituents)
             tmp.extend(new_coords)
         coords_list = tmp
-    
-    # check for rotatable ring amine group
-    coords_list = rotate_amine_substituents(mol, coords_list, max_ff_iter, energy_threshold, debug)
 
     return coords_list
 
@@ -270,9 +267,6 @@ def rotate_amine_substituents(mol: Mol,
     if len(amine_match) == 0:
         return coords_list
     
-    print("jani debug, amine_match")
-    print(amine_match)
-
     for match in amine_match:
         if len(match) == 3:
             n_idx, sub1_idx, sub2_idx = match
@@ -383,6 +377,11 @@ def expand_reasonable_chairs(
         axial_likeliness_range=0.1,
         max_ff_iter = 400):
     
+
+    # check for amine flip in initially supplied coords
+    c = rotate_amine_substituents(mol, [coords], max_ff_iter, energy_threshold, debug)
+    coords = c[0]
+
     if len(idxs) != 6:
         raise RuntimeError("length of idxs is %d but must be 6" % (len(idxs)))
     if calc_boat_likeliness(ringinfo) >= -2:
@@ -429,8 +428,11 @@ def expand_reasonable_chairs(
     new_axial_likeliness = calc_axial_likeliness(substituents, newpos)
     new_axial_likeliness += calc_anomeric_penalty(mol, substituents, newpos)
 
+    # now check for amine flip on new coordinates
+    c = rotate_amine_substituents(mol, [newpos], max_ff_iter, energy_threshold, debug)
+    newpos = c[0]
+
     # a little more debugging
-    debug=True
     if debug:
         print("Mol 1")
         print(am.molToXYZ(mol, coords))

--- a/scrubber/ringfix.py
+++ b/scrubber/ringfix.py
@@ -267,8 +267,11 @@ def rotate_amine_substituents(mol: Mol,
     
     amine_match = am.find_n_ring_substituents(mol)
 
-    if amine_match:
-        n_idx, sub1_idx, sub2_idx = amine_match
+    if len(amine_match) == 0:
+        return coords_list
+
+    for match in amine_match:
+        n_idx, sub1_idx, sub2_idx = match
         ring_atoms = am.get_ring_atoms(mol, n_idx)
         tmp = []
         for coords in coords_list:
@@ -297,9 +300,9 @@ def rotate_amine_substituents(mol: Mol,
                 tmp.append(coords)
                 tmp.append(new_coords)
 
-        return tmp
-    else:
-        return coords_list
+        coords_list = tmp
+
+    return coords_list
 
 
 
@@ -418,8 +421,15 @@ def expand_reasonable_chairs(
     newpos = rotate_corner(idxs[(best_index + 3) % 6], ringinfo, substituents, newpos, rotangle2)
     new_axial_likeliness = calc_axial_likeliness(substituents, newpos)
     new_axial_likeliness += calc_anomeric_penalty(mol, substituents, newpos)
-    
-    if (use_energy): 
+
+    # a little more debugging
+    if debug:
+        print("Mol 1")
+        print(am.molToXYZ(mol, coords))
+        print("Mol 2")
+        print(am.molToXYZ(mol, newpos))
+
+    if (use_energy):
         ## calculate correct conformation by energy comparison ######
         ## MMFF94 forcefield
         

--- a/scrubber/ringfix.py
+++ b/scrubber/ringfix.py
@@ -2,12 +2,16 @@ import numpy as np
 import math
 from rdkit import Chem
 from rdkit.Chem.rdchem import Mol
+from typing import List
 
 from rdkit.Chem import AllChem
 import random
 
 
 from .utils import optimize_conformers, add_conformers_to_mol, write_conformers_to_sdf
+from .utils import rotation_matrix
+from . import amine_flip as am
+
 
 def norm(v):
     return v / np.sqrt(np.dot(v, v))
@@ -243,7 +247,52 @@ def fix_rings(mol: Mol, coords: list, use_energy: bool, energy_threshold: float,
             new_coords = expand_ring6_rot5(coords, idxs, substituents)
             tmp.extend(new_coords)
         coords_list = tmp
+    
+    # check for rotatable ring amine group
+    coords_list = rotate_amine_substituents(mol, coords_list, max_ff_iter, energy_threshold)
+
     return coords_list
+
+
+def rotate_amine_substituents(mol: Mol, 
+                              coords_list: List, 
+                              max_ff_iter: int, 
+                              energy_threshold: float):
+    amine_match = am.find_n_ring_substituents(mol)
+    #jani debug
+    print("jani debug, amine_match: ", amine_match)
+    if amine_match:
+        n_idx, sub1_idx, sub2_idx = amine_match
+        ring_atoms = am.get_ring_atoms(mol, n_idx)
+        tmp = []
+        for coords in coords_list:
+            
+            new_coords =  am.swap_substituents(mol, coords, n_idx, sub1_idx, sub2_idx, ring_atoms)
+
+            mol_with_confs = add_conformers_to_mol(mol, [coords, new_coords])
+            # compare new coords with old coords
+            optimized_energies = optimize_conformers(mol_with_confs, False, max_ff_iter)
+        
+            old_energy = optimized_energies[0][1]
+            new_energy = optimized_energies[1][1]
+            print(f"jani debug, initial energy: {old_energy}")
+            print(f"jani debug, initial coords: {am.molToXYZ(mol, coords)}")
+            print(f"jani debug, rotate energy: {new_energy}")
+            print(f"jani debug, rotated coords: {am.molToXYZ(mol, new_coords)}")
+            if new_energy - old_energy < -energy_threshold:
+                tmp.append(new_coords)
+            elif new_energy - old_energy > energy_threshold:
+                tmp.append(coords)
+            else:
+                tmp.append(coords)
+                tmp.append(new_coords)
+
+        print("jani debug tmp")
+        print(tmp)
+        return tmp
+    else:
+        return coords_list
+
 
 
 def expand_ring6_rot5(coords, idxs, substituents, axial_range=0.1, debug=False):
@@ -528,23 +577,5 @@ def rotate_ring_atom(index, coords, rotaxis, angle, substituents):
     for i in affected:
         coords[i] = np.dot(rotation_matrix(rotaxis, angle), coords[i])
     return coords
-
-def rotation_matrix(axis, theta):
-    """
-    Return the rotation matrix associated with counterclockwise rotation about
-    the given axis by theta radians.
-
-    source: https://stackoverflow.com/questions/6802577/rotation-of-3d-vector
-    """
-
-    axis = np.asarray(axis)
-    axis = axis / math.sqrt(np.dot(axis, axis))
-    a = math.cos(theta / 2.0)
-    b, c, d = -axis * math.sin(theta / 2.0)
-    aa, bb, cc, dd = a * a, b * b, c * c, d * d
-    bc, ad, ac, ab, bd, cd = b * c, a * d, a * c, a * b, b * d, c * d
-    return np.array([[aa + bb - cc - dd, 2 * (bc + ad), 2 * (bd - ac)],
-                     [2 * (bc - ad), aa + cc - bb - dd, 2 * (cd + ab)],
-                     [2 * (bd + ac), 2 * (cd - ab), aa + dd - bb - cc]])
 
 

--- a/scrubber/utils.py
+++ b/scrubber/utils.py
@@ -4,7 +4,9 @@ from rdkit.Chem import rdDistGeom
 from rdkit.Chem import AllChem
 
 from rdkit.ForceField.rdForceField import ForceField
+import math
 
+import numpy as np
 
 def optimize_conformers(mol: Mol, use_mmff: bool=True, max_ff_iter: int = 400):
     optimized_energies = []
@@ -70,3 +72,22 @@ def write_conformers_to_sdf(mol, filename="test.sdf"):
     
     writer.close()
     print(f"All conformers written to {filename}")
+
+
+def rotation_matrix(axis, theta):
+    """
+    Return the rotation matrix associated with counterclockwise rotation about
+    the given axis by theta radians.
+
+    source: https://stackoverflow.com/questions/6802577/rotation-of-3d-vector
+    """
+
+    axis = np.asarray(axis)
+    axis = axis / math.sqrt(np.dot(axis, axis))
+    a = math.cos(theta / 2.0)
+    b, c, d = -axis * math.sin(theta / 2.0)
+    aa, bb, cc, dd = a * a, b * b, c * c, d * d
+    bc, ad, ac, ab, bd, cd = b * c, a * d, a * c, a * b, b * d, c * d
+    return np.array([[aa + bb - cc - dd, 2 * (bc + ad), 2 * (bd - ac)],
+                     [2 * (bc - ad), aa + cc - bb - dd, 2 * (cd + ab)],
+                     [2 * (bd + ac), 2 * (cd - ab), aa + dd - bb - cc]])


### PR DESCRIPTION
This PR implements the ability to flip the substituents of an aliphatic nitrogen within a ring structure. 

Works the following way:

 - Detects [NRX4] smarts pattern, i.e. amine group inside ring when attached to 4 atoms (2 in ring, 2 substituents).
 - Rotates the substituents by 180 degrees on the plane that bisects the two groups.
 - Performs energy optimization and keeps the structure with the lowest energy. 

Currently this happens at the very end of `ringfix`, but we might want to reconsider the order of operations. Similarly, this happens independently of the previous implemented `ring-minimize` functionality. We might want to couple these two together. 