### PR TITLE
Add --use_random_coords option for more robust 3D embedding  

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ What happens:
 
 
 # Installation
+Direct installation:
+```sh
+conda activate <desired-environment>    # if you are using conda environments
+
+pip install git+https://github.com/forlilab/molscrub.git
+
+```
+For developers:
 ```sh
 conda activate <desired-environment>    # if you are using conda environments
 

--- a/molscrub/core.py
+++ b/molscrub/core.py
@@ -37,6 +37,7 @@ class Scrub:
         max_ff_iter=400,
         numconfs=1,
         etkdg_rng_seed=None,
+        use_random_coords=False,
         ff="mmff94s",
         ring_minimize=False,
         energy_threshold=0.5,
@@ -66,6 +67,7 @@ class Scrub:
         self.etkdg_rng_seed = (
             etkdg_rng_seed if etkdg_rng_seed else random.randint(0, 1000000)
         )
+        self.use_random_coords = use_random_coords
         self.ff = ff
         self.keep_all_frags = keep_all_frags
         self.charge_model = charge_model
@@ -126,6 +128,7 @@ class Scrub:
                     skip_ringfix=self.skip_ringfix,
                     max_ff_iter=self.max_ff_iter,
                     etkdg_rng_seed=self.etkdg_rng_seed,
+                    use_random_coords=self.use_random_coords,
                     numconfs=self.numconfs,
                     ff=self.ff,
                     espaloma=self.espaloma,

--- a/molscrub/geometry.py
+++ b/molscrub/geometry.py
@@ -154,6 +154,7 @@ def gen3d(
     skip_ringfix: bool = False,
     max_ff_iter: int = 400,
     etkdg_rng_seed: int = 42,
+    use_random_coords=False,
     numconfs: int = 1,
     ff: str = "mmff94s",
     espaloma=None,
@@ -170,6 +171,7 @@ def gen3d(
     # Set up the ETKDG parameters
     ps = rdDistGeom.ETKDGv3()
     ps.randomSeed = etkdg_rng_seed
+    ps.useRandomCoords = use_random_coords
     ps.trackFailures = True
     ps.enforceChirality = True
     ps.useSmallRingTorsions = True

--- a/scripts/scrub.py
+++ b/scripts/scrub.py
@@ -235,6 +235,7 @@ geom.add_argument("--template", help="Template molecule for 3D embedding with co
 geom.add_argument("--template_smarts", help="SMARTs patter matching atoms of template and query molecules for 3D embedding")
 geom.add_argument("--ring_minimize", help="use FF energy minimization to determine optimal ring conformer", action="store_true")
 geom.add_argument("--energy_threshold", help="energy threshold for conformer distinction", default=0.5, type=float)
+geom.add_argument("--use_random_coords", help="use random coordinates for more robust (but slightly slower) embedding", action="store_true")
 
 misc2 = parser_advanced.add_argument_group("more miscellaneous options")
 misc2.add_argument("--wcg", help="make sure mol names and suffixes are integers", action="store_true")
@@ -364,6 +365,7 @@ scrub = Scrub(
     max_ff_iter=args.max_ff_iter,
     numconfs = nconfs,
     etkdg_rng_seed=args.etkdg_rng_seed,
+    use_random_coords=args.use_random_coords,
     ff=args.ff,
     ring_minimize=args.ring_minimize,
     energy_threshold=args.energy_threshold,


### PR DESCRIPTION
This PR adds a new `--use_random_coords` flag that enables RDKit's random coordinate embedding mode, which in some cases can successfully generate 3D conformations for molecules that fail with the default ETKDG algorithm.  
  
### Background  
As described in Greg Landrum's RDKit blog post [Looking at Random Coordinate Embedding](https://greglandrum.github.io/rdkit-blog/posts/2021-01-31-looking-at-random-coordinate-embedding.html), the `useRandomCoords` parameter provides a more robust embedding approach at the cost of increased computation time.  
  
### Changes  
- Added `--use_random_coords` CLI argument in `scripts/scrub.py`  
- Updated `Scrub` class in `molscrub/core.py` to accept and pass the parameter  
- Modified `gen3d()` in `molscrub/geometry.py` to set `ps.useRandomCoords` on the ETKDG parameters  
  
### Example  
The feature enables processing of complex molecules that previously failed:  
  
```bash  
# This fails with default settings: 
scrub.py "CCCCC/C=C\C/C=C\CCCCCCCC(=O)OC[C@@H](OC(=O)CCCCCCC/C=C\C/C=C\CCCCC)COP(=O)(OCC(O)COP(=O)(OC[C@H](OC(=O)CCCCCCC/C=C\C/C=C\CCCCC)COC(=O)CCCCCCC/C=C\C/C=C\CCCCC)O)O" -o test_random.sdf  
  
# This succeeds with random coordinates: 
scrub.py "CCCCC/C=C\C/C=C\CCCCCCCC(=O)OC[C@@H](OC(=O)CCCCCCC/C=C\C/C=C\CCCCC)COP(=O)(OCC(O)COP(=O)(OC[C@H](OC(=O)CCCCCCC/C=C\C/C=C\CCCCC)COC(=O)CCCCCCC/C=C\C/C=C\CCCCC)O)O" -o test_random.sdf --use_random_coords
```
The default behavior remains unchanged. This simply exposes an existing RDKit option that can be useful in difficult embedding cases.
