### PR TITLE
Fewer tautomers (more precise) and option to drop molecules with duplicated names

### DIFF
--- a/molscrub/data/tautomers.txt
+++ b/molscrub/data/tautomers.txt
@@ -3,7 +3,9 @@
 [nX2,NX2,S,O,Se,Te:1]=,:[C,c,nX2,NX2:6][C,c,NX2,nX2:5]=,:[C,c,nX2,NX2:2][Nh,nh,Sh,sh,Oh,oh,Seh,Teh:3]>>[#1][N,S,O,Se,Te:1][C,NX2:6]=,:[C,N:5][C,#7X2:2]=,:[NX2,S,O,Se,Te:3] P-07
 [nX2,NX2,S,O,Se,Te,Cz0X3:1]:,=[c,C,NX2,nX2:6][C,c,NX2,nX2:5]:,=[C,c,NX2,nX2:2][C,c,NX2,nX2:7]:,=[C,c,NX2,nX2:8][Nh,nh,Sh,sh,Oh,oh,Seh,Teh,CX4z0h:3]>>[#1][N,n,S,O,Se,Te,Cz0X4:1][C,c,NX2,nX2:6]=[C,c:5][C,c,NX2,nX2:2]=[C,c,NX2,nX2:7][C,c,NX2,nX2:8]=[NX2,S,O,Se,Te,CX3z0:3] P-09
 KEEPMAX_SMARTS [a] aromatic
-KEEPMAX_SMARTS [OX1,SX1]=[CX3][NX3] amide
-KEEPMAX_SMARTS [CX4][CX3,PX4](=[OX1]) acetone 
+KEEPMAX_SMARTS [OX1,SX1]=[#6X3][#7X3] amide
+# KEEPMAX_SMARTS [CX4][CX3,PX4](=[OX1]) acetone 
 KEEPMIN_SMARTS [#6X3][NX4+1] anilinium
-KEEPMIN_SMARTS [#7X2H1+0]=[*] imine
+KEEPMIN_SMARTS [NX2+0]=c imine
+KEEPMIN_SMARTS [NX3+0]C=C enamine
+KEEPMIN_SMARTS [#6]=[CX3,PX4][OX2H1] enol

--- a/molscrub/data/tautomers.txt
+++ b/molscrub/data/tautomers.txt
@@ -6,3 +6,4 @@ KEEPMAX_SMARTS [a] aromatic
 KEEPMAX_SMARTS [OX1,SX1]=[CX3][NX3] amide
 KEEPMAX_SMARTS [CX4][CX3,PX4](=[OX1]) acetone 
 KEEPMIN_SMARTS [#6X3][NX4+1] anilinium
+KEEPMIN_SMARTS [#7X2H1+0]=[*] imine

--- a/scripts/scrub.py
+++ b/scripts/scrub.py
@@ -159,12 +159,11 @@ class MolSupplier:
                 is_repeated = True
                 while is_repeated:
                     mol = self.supplier.__next__()
+                    if mol is None:
+                        return mol
                     name = mol.GetProp("_Name")
                     is_repeated = name in self.names
-                if is_repeated:
-                    raise StopIteration
-            else:
-                self.names.add(name)
+            self.names.add(name)
         if self.rename_to_int:
             name = mol.GetProp("_Name")
             newname = self._rename(name)

--- a/scripts/scrub.py
+++ b/scripts/scrub.py
@@ -132,12 +132,14 @@ class MolSupplier:
         molecule names to integers, and to set rdkit mol names from properties
     """
 
-    def __init__(self, supplier, name_from_prop=None, rename_to_int=False, nr_digits=10):
+    def __init__(self, supplier, name_from_prop=None, rename_to_int=False, nr_digits=10, drop_duplicate_names=False):
         self.supplier = supplier
         self.name_from_prop = name_from_prop
         self.rename_to_int = rename_to_int
         self.nr_digits = nr_digits
-        self.names = {}
+        self.drop_duplicate_names = drop_duplicate_names
+        self.counter_to_names = {}
+        self.names = set()
         self.counter = 0
         
     def __iter__(self):
@@ -151,6 +153,18 @@ class MolSupplier:
         if self.name_from_prop:
             name = mol.GetProp(self.name_from_prop)
             mol.SetProp("_Name", name)
+        if self.drop_duplicate_names:
+            name = mol.GetProp("_Name")
+            if name in self.names:
+                is_repeated = True
+                while is_repeated:
+                    mol = self.supplier.__next__()
+                    name = mol.GetProp("_Name")
+                    is_repeated = name in self.names
+                if is_repeated:
+                    raise StopIteration
+            else:
+                self.names.add(name)
         if self.rename_to_int:
             name = mol.GetProp("_Name")
             newname = self._rename(name)
@@ -181,7 +195,7 @@ class MolSupplier:
         #if name in self.names:
         #    raise RuntimeError("repeated molecule name: %s" % name)
         #self.names[name] = self.counter
-        self.names[self.counter] = name
+        self.counter_to_names[self.counter] = name
         tmp = "RN%0" + "%d" % self.nr_digits + "d"
         return tmp % self.counter
 
@@ -211,6 +225,7 @@ basic = parser.add_argument_group("options")
 basic.add_argument("-o", "--out_fname", help="output filename (.sdf/.hdf5)", required=True)
 basic.add_argument("--write_failed_mols", help="filename for failed molecules (.sdf)")
 basic.add_argument("--name_from_prop", help="set molecule name from RDKit/SDF property")
+basic.add_argument("--drop_duplicate_names", help="ignore duplicate molecules based on name field", action="store_true")
 basic.add_argument("--ph", help="pH value for acid/base transformations", default=7.4, type=float)
 basic.add_argument("--skip_acidbase", help="skip enumeration of acid/base conjugates", action="store_true")
 basic.add_argument("--skip_tautomers", help="skip enumeration of tautomers", action="store_true")
@@ -314,11 +329,12 @@ if args.template_smarts is not None:
 else:
     template_smarts = None
 
-if args.wcg or args.name_from_prop:
+if args.wcg or args.name_from_prop or args.drop_duplicate_names:
     supplier = MolSupplier(
         supplier,
         name_from_prop=args.name_from_prop,
-        rename_to_int=args.wcg
+        rename_to_int=args.wcg,
+        drop_duplicate_names=args.drop_duplicate_names,
     )
 
 # output
@@ -468,5 +484,5 @@ if __name__ == '__main__':
         fname = pathlib.Path(args.out_fname).with_suffix(".renaming.json")
         print("Writing %s" % (fname))
         with open(fname, "w") as f:
-            json.dump(supplier.names, f)
+            json.dump(supplier.counter_to_names, f)
         print("Done.")


### PR DESCRIPTION
This PR adds two features: option `drop_duplicate_names` to skip molecules with names that have already been processed, and a better set of rules for enumerating tautomers, specifically the rules that keep only the tautomers with the maximum or minimum number of occurrences of each pattern:
 - max amides: now includes aromatic amides
 - max acetone: replaced by min enols
 - add min imine adjacent to aromatic atoms (frequent in nucleotide bases)
 - add min enamine
On the NIH tautomer database, this increased precision in identifying prevalent tautomers (categories 2, 3, and 4) from 32.5 to 38.7 %, with a minimal increase in recall from 50.1 to 50.5 %. 