### PR TITLE
fix: clarify script errors (scrub.py) when Scrub() instance returns []

### DIFF
--- a/molscrub/core.py
+++ b/molscrub/core.py
@@ -276,6 +276,15 @@ class Scrub:
         log["input_mol_none"] = False
         try:
             isomer_list_if_ok_else_input = self(input_mol)
+            if (type(isomer_list_if_ok_else_input) == list
+                and len(isomer_list_if_ok_else_input) == 0):
+                isomer_list_if_ok_else_input = input_mol
+                if input_mol.HasProp("_Name"):
+                    name_str = f" (name: {input_mol.GetProp('_Name')})"
+                else:
+                    name_str = ""
+                log["exception"] = f"Scrub instance returned an empty list (BUG LIKELY) returning input mol instead{name_str}."
+                
         except Exception as e:
             log["exception"] = e
             isomer_list_if_ok_else_input = input_mol

--- a/scripts/scrub.py
+++ b/scripts/scrub.py
@@ -435,13 +435,16 @@ def write_and_log(isomer_list, log, counter, writer, failed_mol_writer=None):
             print(get_info_str(counter))
     else:
         counter["failed"] += 1
-        if "exception" in log:
-            print(log["exception"], file=sys.stderr)
-        print("Programming logic error. This should not be reached. Please report on GitHub")
-        print("scrub_and_catch_errors returns (isomer_list_if_ok_else_input, log)")
-        print("and it is expected that log (type dict) has key 'exception' if not returning a list")
-        print("but that didn't happen.")
-
+        print("The output from molscrub is unnexpected - please report on GitHub")
+        print(f"{type(isomer_list)=}")
+        print(f"{log=}")
+        if type(isomer_list) == Chem.Mol:
+            if isomer_list.HasProp("_Name"):
+                print(f"Molecule name: {isomer_list.GetProp('_Name')}")
+            print(f"SMILES: {Chem.MolToSmiles(isomer_list)}")
+            print(f"an 'exception' key was expected in log because a Mol instance was returned instead of a list of Mols")
+        elif type(isomer_list) == list and not len(isomer_list):
+            print(f"the output of Scrub instance is an empty list - this should not have happened - likely bug")
 
 if args.write_failed_mols is not None:
      sdwriter_failures = Chem.SDWriter(args.write_failed_mols)


### PR DESCRIPTION
If the AcidBaseConjugator returns an empty list (due to ETR1 pKa values greater and lesser than the threshold pH for an acid/base pair), the Scrub() instance also returns an empty list. The expected output is a list of molecules, or the input molecule alongside an error message in `log["exception"]`. This tripped the script scrub.py into the following useless output:
```
Programming logic error. This should not be reached. Please report on GitHub
scrub_and_catch_errors returns (isomer_list_if_ok_else_input, log)
and it is expected that log (type dict) has key 'exception' if not returning a list
but that didn't happen.
```
After this PR we get:
```
Scrub instance returned an empty list (BUG LIKELY) returning input mol instead (name: Z2866903078).
```